### PR TITLE
Add dockerfile, helm charts and update README

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,6 +23,10 @@ build: vendor
 	GOOS=darwin go build -o bin/darwin/$(HOST_GOARCH)/kuberang -ldflags $(BUILD_FLAGS) ./cmd
 	GOOS=linux go build -o bin/linux/$(HOST_GOARCH)/kuberang -ldflags $(BUILD_FLAGS) ./cmd
 
+docker: vendor
+	CGO_ENABLED=0 GOOS=linux go build -a -o docker/kuberang -ldflags $(BUILD_FLAGS) ./cmd
+	docker build --rm -t kuberang:$(VERSION) docker/
+
 clean:
 	rm -rf bin
 	rm -rf out

--- a/README.md
+++ b/README.md
@@ -67,6 +67,11 @@ In order to clean:
 make clean
 ```
 
+In order to produce a docker image:
+```
+make docker
+```
+
 In order to produce the distribution package:
 ```
 make dist

--- a/charts/Chart.yaml
+++ b/charts/Chart.yaml
@@ -1,0 +1,4 @@
+name: kuberang
+version: 0.1.1
+description: kuberang is a command-line utility for smoke testing a Kubernetes install.
+

--- a/charts/README.md
+++ b/charts/README.md
@@ -1,0 +1,53 @@
+#Kuberang Helm Charts
+
+kuberang is a command-line utility for smoke testing a Kubernetes install.
+
+It scales out a pair of services, checks their connectivity, and then scales back in again.
+
+Here, kuberang will be run as CronJob, set to run every 30 minutes.
+
+To retrieve the logs, we need to determine the pod the job was executed on:
+
+```
+KUBERANG_POD=$(kubectl get pods -a --selector=type=kuberang-logging --output=jsonpath={.items..metadata.name})
+```
+Note: add the `-n <namespace>` option if you are running kuberang in a namespace.
+
+(The 'type' label was added to the job definition in order to allow this filtering).
+
+Then ```kubectl logs $KUBERANG_POD -n <namespace>``` will produce the logs, e.g:
+
+```
+Kubectl configured on this node                                                 [OK]
+Delete existing deployments if they exist                                       [OK]
+Nginx service does not already exist                                            [OK]
+BusyBox service does not already exist                                          [OK]
+Nginx service does not already exist                                            [OK]
+Issued BusyBox start request                                                    [OK]
+Issued Nginx start request                                                      [OK]
+Issued expose Nginx service request                                             [OK]
+Both deployments completed successfully within timeout                          [OK]
+Grab nginx pod ip addresses                                                     [OK]
+Grab nginx service ip address                                                   [OK]
+Grab BusyBox pod name                                                           [OK]
+Accessed Nginx service at 192.168.139.151 from BusyBox                          [OK]
+Accessed Nginx service via DNS kuberang-nginx-1515421803094247236 from BusyBox  [OK]
+Accessed Nginx pod at 192.168.103.241 from BusyBox                              [OK]
+Accessed Nginx pod at 192.168.53.185 from BusyBox                               [OK]
+Accessed Nginx pod at 192.168.56.170 from BusyBox                               [OK]
+Accessed Nginx pod at 192.168.103.240 from BusyBox                              [OK]
+Accessed Nginx pod at 192.168.53.184 from BusyBox                               [OK]
+Accessed Nginx pod at 192.168.56.169 from BusyBox                               [OK]
+Accessed Google.com from BusyBox                                                [ERROR IGNORED]
+Accessed Nginx pod at 192.168.103.241 from this node                            [OK]
+Accessed Nginx pod at 192.168.53.185 from this node                             [OK]
+Accessed Nginx pod at 192.168.56.170 from this node                             [OK]
+Accessed Nginx pod at 192.168.103.240 from this node                            [OK]
+Accessed Nginx pod at 192.168.53.184 from this node                             [OK]
+Accessed Nginx pod at 192.168.56.169 from this node                             [OK]
+Accessed Google.com from this node                                              [ERROR IGNORED]
+Powered down Nginx service                                                      [OK]
+Powered down Busybox deployment                                                 [OK]
+Powered down Nginx deployment                                                   [OK]
+
+```

--- a/charts/templates/clusterrole.yaml
+++ b/charts/templates/clusterrole.yaml
@@ -1,0 +1,21 @@
+{{- if and .Values.enabled .Values.rbac.create -}}
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRole
+metadata:
+  name: kuberang-{{ .Release.Name }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app: kuberang
+    chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+rules:
+  - apiGroups: 
+      - "*"
+    resources: 
+      - "nodes"
+    verbs: 
+      - "get"
+      - "update"
+      - "list"
+{{- end -}}

--- a/charts/templates/clusterrolebinding.yaml
+++ b/charts/templates/clusterrolebinding.yaml
@@ -1,0 +1,19 @@
+{{- if and .Values.enabled .Values.rbac.create -}}
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: kuberang-{{ .Release.Name }}
+  labels:
+    app: kuberang
+    chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+roleRef:
+  kind: ClusterRole
+  name: kuberang-{{ .Release.Name }}
+  apiGroup: rbac.authorization.k8s.io
+subjects:
+- kind: ServiceAccount
+  name: kuberang-{{ .Release.Name }}
+  namespace: mantle
+{{- end -}}

--- a/charts/templates/cronjob.yaml
+++ b/charts/templates/cronjob.yaml
@@ -1,0 +1,25 @@
+{{- if .Values.enabled -}}
+apiVersion: batch/v1beta1
+kind: CronJob
+metadata:
+  name: "kuberang-{{ .Release.Name }}"
+spec:
+  schedule: "*/30 * * * *"
+  successfulJobsHistoryLimit: 1
+  jobTemplate:
+    spec:
+      template:
+        metadata:
+          name: kuberang-{{ .Release.Name }}
+          labels:
+            chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+            heritage: {{ .Release.Service }}
+            type: kuberang-logging
+        spec:
+          containers:
+          - name: kuberang
+            image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          restartPolicy: Never
+          serviceAccount: kuberang-{{ .Release.Name }}
+          serviceAccountName: kuberang-{{ .Release.Name }}
+{{- end -}}

--- a/charts/templates/role.yaml
+++ b/charts/templates/role.yaml
@@ -1,0 +1,52 @@
+{{- if and .Values.enabled .Values.rbac.create -}}
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: Role
+metadata:
+  name: kuberang-{{ .Release.Name }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app: kuberang
+    chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+rules:
+  - apiGroups: 
+      - "extensions"
+    resources: 
+      - "deployments"
+    verbs: 
+      - "get"
+      - "create"
+      - "update"
+      - "delete"
+  - apiGroups: 
+      - "extensions"
+    resources: 
+      - "replicasets"
+    verbs: 
+      - "list"
+      - "get"
+      - "update"
+      - "delete"
+  - apiGroups: 
+      - "*"
+    resources: 
+      - "services"
+    verbs: 
+      - "get"
+      - "create"
+      - "post"
+      - "delete"
+  - apiGroups: 
+      - "*"
+    resources: 
+      - "pods"
+      - "pods/exec"
+    verbs: 
+      - "get"
+      - "list"
+      - "create"
+      - "delete"
+      - "post"
+      - "update" 
+{{- end -}}

--- a/charts/templates/rolebinding.yaml
+++ b/charts/templates/rolebinding.yaml
@@ -1,0 +1,20 @@
+{{- if and .Values.enabled .Values.rbac.create -}}
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: RoleBinding
+metadata:
+  name: kuberang-{{ .Release.Name }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app: kuberang
+    chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: kuberang-{{ .Release.Name }}
+subjects:
+  - kind: ServiceAccount
+    name: kuberang-{{ .Release.Name }}
+    namespace: {{ .Release.Namespace }}
+{{- end -}}

--- a/charts/templates/serviceaccount.yaml
+++ b/charts/templates/serviceaccount.yaml
@@ -1,0 +1,11 @@
+{{- if and .Values.enabled .Values.rbac.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: kuberang-{{ .Release.Name }}
+  labels:
+    app: kuberang
+    chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+{{- end -}}

--- a/charts/values.yaml
+++ b/charts/values.yaml
@@ -1,0 +1,14 @@
+#Whether kuberang is enabled or not
+enabled: true
+
+#The repository and tag of the kuberang image you want to run
+image:
+  repository:
+  tag: #E.g: "latest"
+  pullPolicy: Always
+
+#Create the necessary RBAC resources
+rbac:
+  create: true
+
+replicaCount: 1

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,11 @@
+FROM alpine:3.7
+
+ENV USER root
+
+RUN apk add --no-cache curl
+RUN curl -LO https://storage.googleapis.com/kubernetes-release/release/$(curl -s http://storage.googleapis.com/kubernetes-release/release/stable.txt)/bin/linux/amd64/kubectl \
+    && mv /kubectl /bin/kubectl \
+    && chmod +x /bin/kubectl
+
+COPY kuberang /
+ENTRYPOINT ["/kuberang"]


### PR DESCRIPTION
This PR adds a dockerfile, aswell as helm charts.
In this case, kuberang has been deployed as a CronJob, and some documentation on retrieving logs can be found within the charts directory.